### PR TITLE
[Browse Map] Route points are not always updated when clearing or moving them

### DIFF
--- a/Geocaching_Map_Enhancements.user.js
+++ b/Geocaching_Map_Enhancements.user.js
@@ -1561,8 +1561,9 @@ var gmeResources = {
                         return L.Polyline.prototype.onRemove.call(this, map);
                     },
                     removePt: function(num) {
-                        this.spliceLatLngs(num-1,1);
-                        this._updateMarkers();
+                        var latlngs = this.getLatLngs();
+                        latlngs.splice(num-1,1);
+                        this.setLatLngs(latlngs);
                     },
                     setLatLngs: function(pts) {
                         L.Polyline.prototype.setLatLngs.call(this, pts);
@@ -1583,8 +1584,9 @@ var gmeResources = {
                         }
                     },
                     _moveMarker: function(e) {
-                        this.spliceLatLngs(e.target._routeNum - 1, 1, e.target.getLatLng());
-                        this._updateLength();
+                        var latlngs = this.getLatLngs();
+                        latlngs.splice(e.target._routeNum - 1, 1, e.target.getLatLng());
+                        this.setLatLngs(latlngs);
                     },
                     _updateLength: function() {
                         var i;


### PR DESCRIPTION
Route points on Browse Map are not always updated when clearing or moving them:
- Moving a route point does not drag the blue route line along with it, nor amend the resulting distance between points. 
- Clearing a single route point does not work.

Bug in Console: `Uncaught TypeError: this.spliceLatLngs is not a function`
Reason: `spliceLatLngs` was removed in higher Leaflet versions.

Testing:
- [x] Browse Map
- [x] Trackable Map
- [x] Hide process maps

Related to #93.
